### PR TITLE
Provide compatibility with Foliant 1.0.8.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 foliant-docs
+Copyright (c) 2018 foliant-docs
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+# 1.1.5 (under development)
+
+-   Provide compatibility with Foliant 1.0.8.
+
 # 1.1.4
 
 -   Code refactored.

--- a/foliant/cli/gupload.py
+++ b/foliant/cli/gupload.py
@@ -117,7 +117,7 @@ class Cli(BaseCli):
 
         self._gdrive_auth()
 
-        with spinner(f"Uploading '{self._filename}' to Google Drive", self.logger, quiet=False):
+        with spinner(f"Uploading '{self._filename}' to Google Drive", self.logger, quiet=False, debug=False):
             try:
                 self._create_gdrive_folder()
                 self._upload_file(target)

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     license='MIT',
     platforms='any',
     install_requires=[
-        'foliant>=1.0.5',
+        'foliant>=1.0.8',
         'cliar',
         'PyDrive'
     ],


### PR DESCRIPTION
Use the updated `spinner()` method.